### PR TITLE
fix: rss-plugin hash

### DIFF
--- a/mkdocs-rss-plugin/default.nix
+++ b/mkdocs-rss-plugin/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "Guts";
     repo = pname;
     rev = version;
-    hash = "sha256-yQR2Lqq3qbXUM1/ZXkBDPF1yV2wCE/BHv4Qhod4dD+M=";
+    hash = "sha256-EWgkcG1jOSP7lPVBH2GT/NGVIL0kEkYgt9uQThn3EBo=";
     leaveDotGit = true;
   };
 


### PR DESCRIPTION
Hello,

I haven't looked into what changed between those two hashes yet, but as both my local nix builder and two runs of Github CI agree that this is the correct one, I took the liberty of opening this PR.

Ran into this when devShells and CI builds for srvos broke, see e.g.:
https://github.com/numtide/srvos/actions/runs/5377355182/jobs/9755714121?pr=174